### PR TITLE
Broadcaster doesn't block + 100% test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ __pycache__
 **/*.dylib
 **/*.dll
 **/*.exe
+**/*.exe~
 **/*.syso
 **/*.test
 **/*.prof
@@ -142,4 +143,5 @@ sourcemap.js
 .jest/
 coverage/
 
-# Repository
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TODO: Fill out this long description.
 ## Install
 
 ```
-go get github.com/textileio/go-reflux
+go get github.com/textileio/go-eventstore
 ```
 
 ## Usage

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -41,6 +43,83 @@ func TestSend(t *testing.T) {
 	})
 	wg.Add(N)
 	b.Send(testStr)
+	wg.Wait()
+}
+
+func TestSendError(t *testing.T) {
+	var b Broadcaster
+	// Register listeners, but do not consume
+	b.Listen()
+	b.Listen()
+	b.Listen()
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error when no consumers")
+		if multi, ok := err.(*multierror.Error); ok {
+			if len(multi.Errors) != 3 {
+				t.Error("expected 3 errors")
+			}
+		} else {
+			t.Error("expected a multi-error")
+		}
+	}
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error when no consumers")
+	}
+}
+
+func TestListenAndSendOnClosed(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Test should have panicked")
+		}
+	}()
+	var b = NewBroadcaster(5)
+	b.Discard()
+	b.Listen()
+	b.Send(testStr)
+}
+
+func TestListenAndSendOnCloseWithTimeout(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Test should have panicked")
+		}
+	}()
+	var b = NewBroadcaster(5)
+	b.Discard()
+	b.Listen()
+	b.SendWithTimeout(testStr, 0)
+}
+
+func TestSendWithTimeout(t *testing.T) {
+	var b Broadcaster
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(i int, b *Broadcaster, wg *sync.WaitGroup) {
+		l := b.Listen()
+		wg.Done()
+		time.Sleep(time.Second)
+		select {
+		case v := <-l.Channel():
+			if v.(string) != testStr {
+				t.Error("bad value received")
+			}
+		case <-time.After(timeout):
+			t.Error("receive timed out")
+		}
+		wg.Done()
+	}(1, &b, &wg)
+	wg.Wait()
+	wg.Add(1)
+	if err := b.Send(testStr); err == nil {
+		t.Error("should error")
+	}
+	if err := b.SendWithTimeout(testStr, 0); err == nil {
+		t.Error("should error within 1 second")
+	}
+	if err := b.SendWithTimeout(testStr, 2*time.Second); err != nil {
+		t.Error("should not error within 2 seconds")
+	}
 	wg.Wait()
 }
 

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -68,27 +68,29 @@ func TestSendError(t *testing.T) {
 }
 
 func TestListenAndSendOnClosed(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Test should have panicked")
-		}
-	}()
 	var b = NewBroadcaster(5)
 	b.Discard()
 	b.Listen()
-	b.Send(testStr)
+	err := b.Send(testStr)
+	if err != ErrClosedChannel {
+		t.Errorf("Test should raise closed channel error: %s", err.Error())
+	}
+	if err.Error() != "send after close" {
+		t.Error("Test should raise `send after close`")
+	}
 }
 
 func TestListenAndSendOnCloseWithTimeout(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Test should have panicked")
-		}
-	}()
 	var b = NewBroadcaster(5)
 	b.Discard()
 	b.Listen()
-	b.SendWithTimeout(testStr, 0)
+	err := b.SendWithTimeout(testStr, 0)
+	if err != ErrClosedChannel {
+		t.Errorf("Test should raise closed channel error: %s", err.Error())
+	}
+	if err.Error() != "send after close" {
+		t.Error("Test should raise `send after close`")
+	}
 }
 
 func TestSendWithTimeout(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.12
 
 require (
 	github.com/coreos/etcd v3.3.15+incompatible
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/ipfs/go-datastore v0.1.0
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v1.1.0 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,10 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/ipfs/go-datastore v0.1.0 h1:TOxI04l8CmO4zGtesENhzm4PwkFwJXY3rKiYaaMf9fI=
 github.com/ipfs/go-datastore v0.1.0/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
@@ -47,6 +51,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
### Issue or RFC Endorsed by Textile's Maintainers

Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

### Description of the Change

This improvement was inspired by some comments by @jsign on Slack relating to slow consumers blocking the broadcaster. He suggested a timeout, which this PR also supports. It also necessarily improves test coverage to test these new features.

### Alternate Designs

We could have gone with a default timeout, but this felt more useful potentially. It also uses [multi-errors](https://godoc.org/github.com/hashicorp/go-multierror), which seemed like a really nice enhancement (also inspired by a comment by @jsign).

### Possible Drawbacks

We'll have to decide is a non-blocking broadcaster is indeed what we want elsewhere.

### Verification Process

New tests were added to verify the new feature is doing what it claims to be doing.

### Release Notes

Broadcaster is now non-blocking, and will return a [multierror](https://godoc.org/github.com/hashicorp/go-multierror) if it is unable to broadcast to given channel(s). Test coverage for broadcaster was increased to 100%.