### PR TITLE
deprecated repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATED
+This repository is DEPRECATED, all contents were moved to [go-textile-threads](https://github.com/textileio/go-textile-threads).
+
 # go-eventstore
 
 [![Made by Textile](https://img.shields.io/badge/made%20by-Textile-informational.svg?style=flat-square)](https://textile.io)


### PR DESCRIPTION
Add the corresponding notice that this repo will not be maintained but for archiving.

See: https://github.com/textileio/go-textile-threads/pull/45